### PR TITLE
Concept robustness

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,3 +9,4 @@ Additional Contributors are
 * Tom Hanika        (Concept Probability)
 * Gleb Kanterov     (interval-scale)
 * Johannes Wollbold (bug reports, feature requests)
+* Maximilian Stubbemann (concept-robustness)

--- a/src/main/clojure/conexp/fca/more.clj
+++ b/src/main/clojure/conexp/fca/more.clj
@@ -261,11 +261,11 @@
 (defn concept-robustness-polynomial
   "For the given `concept' of a context, the polynomial p, corresponding to the robustness,
    is computed by using the seq `concepts' of all concepts of the context.
-   The optional boolean parameter `sorted?' allows, to declare the list of concepts
+   The optional boolean parameter `sorted?' allows, to declare the seq of concepts
    as beeing already sorted by increasing attributeset.
    See Finding Robust Itemsets under Subsampling from Tatti, Moerchen and Calders
    https://dl.acm.org/citation.cfm?doid=2676651.2656261 (page 17-19) for details.
-   If v is the result of (robustness-polynom concept concepts),
+   If v is the result of (robustness-polynomial concept concepts),
    then (eval-polynomial v (- 1 alpha)) computes the robustness with parameter alpha."
   ([concept concepts sorted?]
    (assert (or (true? sorted?) (false? sorted?)) "Third argument must be a boolean!")
@@ -274,13 +274,13 @@
                               (filter #(subset? B (second %)) concepts)
                               (sort-by #(count (second %))
                                        (filter #(subset? B (second %)) concepts))))
-       concepts-with-values (reduce ;Stores for all subconcepts (C_A,C_B) of 'concept' the vector [C, e(C_B, 'concept')].
+       concepts-with-values (reduce ;Stores for all subconcepts (C_A,C_B) of `concept' the vector [C, e(C_B, `concept')].
                                 (fn [x y]
                                 (addnextentry y x))
                               [[concept, 1]]
                               usedconcepts)
        sup (count (first concept))]
-     (reduce ;Use the above computed values [C, e(C_B, 'concept')] to compute the polynomial.
+     (reduce ;Use the above computed values [C, e(C_B, `concept')] to compute the polynomial.
         (fn [oldcoefficients entry]
           (let [index (- sup (count (first (first entry))))]
             (assoc oldcoefficients index (+ (nth oldcoefficients index) (second entry)))))
@@ -292,8 +292,8 @@
 (defn concept-robustness
   "Computes the robustness of a `concept' in a context with parameter `alpha'
    by using the seq `concepts', which contains all concepts of the context.
-   The optional boolean parameter `sorted' allows to declare the list of concepts
-   as beeing already sorted by increasing size of the attributeset.?
+   The optional boolean parameter `sorted?' allows to declare the seq of concepts
+   as beeing already sorted by increasing size of the attributeset.
    This function uses the function concept-robustness-polynomial."
   ([concept concepts alpha sorted?]
    (assert (<= 0 alpha 1) "Third argument must be between 0 and 1!")

--- a/src/main/clojure/conexp/fca/more.clj
+++ b/src/main/clojure/conexp/fca/more.clj
@@ -302,5 +302,25 @@
   ([concept concepts alpha]
    (concept-robustness concept concepts alpha false)))
 
+;;; Average robustness of all concepts of a context.
+
+(defn average-concept-robustness
+  "Takes the seq `concepts' which should contain the concepts of a context
+   and computes the average concept robustness with parmater `alpha'."
+  [concepts alpha]
+  (assert (<= 0 alpha 1) "Second argument must be between 0 and 1!")
+  (let [sortedconcepts (sort-by
+                         #(count (second %))
+                         concepts)
+        n (count sortedconcepts)
+        robustness-values (map
+                            #(concept-robustness
+                               (nth sortedconcepts %)
+                               (drop % sortedconcepts)
+                               alpha
+                               true)
+                            (range 0 n))]
+    (/ (reduce + robustness-values) n)))
+
 ;;;
 nil

--- a/src/main/clojure/conexp/fca/more.clj
+++ b/src/main/clojure/conexp/fca/more.clj
@@ -13,7 +13,8 @@
             [conexp.fca
              [contexts :refer :all]
              [exploration :refer :all]
-             [implications :refer :all]]))
+             [implications :refer :all]]
+            [conexp.math.util :refer [eval-polynomial]]))
 
 ;;; Bonds
 
@@ -242,3 +243,64 @@
            (* p_B_k p_B)
            (/ one_minus_p_B_k (- 1 p_B))
            (mapv (partial *) P_M_B_k P_M_B)))))))
+
+;;;;;Robustness of Concepts
+(defn- addnextentry
+  "Helper-function for concept-robustness-polynomial:
+   Computes the value e(Y,`concept'), based on the already computed values e(Z,`concept') which are stored
+   in the second parameter `list' in the form [Z, e(Z, `concept')].
+   This function is needed in the algorithm on page 19 in:
+   https://dl.acm.org/citation.cfm?doid=2676651.2656261."
+  [concept list]
+  (let [newvalue (reduce
+                   (fn [x V] (- x (second V)))
+                   0
+                   (filter #(subset? (second (first %)) (second concept)) list))]
+    (conj list [concept, newvalue])))
+
+(defn concept-robustness-polynomial
+  "For the given `concept' of a context, the polynomial p, corresponding to the robustness,
+   is computed by using the seq `concepts' of all concepts of the context.
+   The optional boolean parameter `sorted?' allows, to declare the list of concepts
+   as beeing already sorted by increasing attributeset.
+   See Finding Robust Itemsets under Subsampling from Tatti, Moerchen and Calders
+   https://dl.acm.org/citation.cfm?doid=2676651.2656261 (page 17-19) for details.
+   If v is the result of (robustness-polynom concept concepts),
+   then (eval-polynomial v (- 1 alpha)) computes the robustness with parameter alpha."
+  ([concept concepts sorted?]
+   (assert (or (true? sorted?) (false? sorted?)) "Third argument must be a boolean!")
+   (let [B (second concept)
+       usedconcepts (drop 1 (if sorted?
+                              (filter #(subset? B (second %)) concepts)
+                              (sort-by #(count (second %))
+                                       (filter #(subset? B (second %)) concepts))))
+       concepts-with-values (reduce ;Stores for all subconcepts (C_A,C_B) of 'concept' the vector [C, e(C_B, 'concept')].
+                                (fn [x y]
+                                (addnextentry y x))
+                              [[concept, 1]]
+                              usedconcepts)
+       sup (count (first concept))]
+     (reduce ;Use the above computed values [C, e(C_B, 'concept')] to compute the polynomial.
+        (fn [oldcoefficients entry]
+          (let [index (- sup (count (first (first entry))))]
+            (assoc oldcoefficients index (+ (nth oldcoefficients index) (second entry)))))
+         (vec (take (+ 1 sup) (repeat 0)))
+         concepts-with-values)))
+  ([concept concepts]
+   (concept-robustness-polynomial concept concepts false)))
+
+(defn concept-robustness
+  "Computes the robustness of a `concept' in a context with parameter `alpha'
+   by using the seq `concepts', which contains all concepts of the context.
+   The optional boolean parameter `sorted' allows to declare the list of concepts
+   as beeing already sorted by increasing size of the attributeset.?
+   This function uses the function concept-robustness-polynomial."
+  ([concept concepts alpha sorted?]
+   (assert (<= 0 alpha 1) "Third argument must be between 0 and 1!")
+   (assert (or (true? sorted?) (false? sorted?)) "Fourth argument must be between 0 and 1!")
+   (eval-polynomial (concept-robustness-polynomial concept concepts sorted?) (- 1 alpha)))
+  ([concept concepts alpha]
+   (concept-robustness concept concepts alpha false)))
+
+;;;
+nil

--- a/src/main/clojure/conexp/fca/more.clj
+++ b/src/main/clojure/conexp/fca/more.clj
@@ -297,7 +297,7 @@
    This function uses the function concept-robustness-polynomial."
   ([concept concepts alpha sorted?]
    (assert (<= 0 alpha 1) "Third argument must be between 0 and 1!")
-   (assert (or (true? sorted?) (false? sorted?)) "Fourth argument must be between 0 and 1!")
+   (assert (or (true? sorted?) (false? sorted?)) "Fourth argument must be a boolean value!")
    (eval-polynomial (concept-robustness-polynomial concept concepts sorted?) (- 1 alpha)))
   ([concept concepts alpha]
    (concept-robustness concept concepts alpha false)))

--- a/src/main/clojure/conexp/math/util.clj
+++ b/src/main/clojure/conexp/math/util.clj
@@ -92,6 +92,20 @@
         (recur (inc run) (* (/ (- target run) run) result))))))
 
 
-;;;
+;;;; Evaluation of Polynomials.
 
+(defn eval-polynomial
+  "Evaluates the polynomial p, represented by it`s Coefficient-vector,
+  at the point value. The function uses the 'Horner Schema', see:
+  https://de.wikipedia.org/wiki/Horner-Schema."
+  [coefficients value]
+  (assert (and (sequential? coefficients) (not (empty? coefficients))) "First argument must be a list of coefficients.")
+  (assert (number? value) "Second argument must be a real number.")
+  (reduce
+    (fn [x y]
+      (+ (* value x) y))
+    0
+    (reverse coefficients)))
+
+;;;;
 nil

--- a/src/test/clojure/conexp/fca/more_test.clj
+++ b/src/test/clojure/conexp/fca/more_test.clj
@@ -120,3 +120,41 @@
                         (concepts context)))
          (expt 2 (count (objects context)))))))
 
+;;;
+
+(deftest test-concept-robustness
+  (let [ctx1 (make-context-from-matrix 3 3
+                                       [0 0 1
+                                        1 0 1
+                                        1 1 0])
+        cpt1 [#{0 1} #{2}]
+        ctx2 (make-context-from-matrix ['a 'b 'c 'd 'e 'f]
+                                       ['a 'b 'c 'd 'e 'f]
+                                       [1 1 1 0 1 1
+                                        0 1 0 0 1 0
+                                        0 0 1 0 0 1
+                                        0 0 0 1 1 1
+                                        0 0 0 0 1 0
+                                        0 0 0 0 0 1])
+        concepts1 (concepts ctx1)
+        concepts2 (concepts ctx2)
+        cpt2 [#{'d} #{'d 'e 'f}]
+        cpt3 [#{'a 'd} #{'e 'f}]
+        rctx (random-context 10 0.5)
+        conceptsr1 (concepts rctx)
+        rctx2 (random-context 15 0.3)
+        conceptsr2 (concepts rctx2)]
+    
+    (is (= (concept-robustness cpt1 concepts1 (/ 1 3)) (/ 1 3)))
+    (is (= (concept-robustness cpt2 concepts2 (/ 3 4)) (/ 3 4)))
+    (is (= (concept-robustness cpt3 concepts2 (/ 1 2)) (/ 1 4)))
+    
+    (with-testing-data [cpt conceptsr1]
+      (and (<= 0 (concept-robustness cpt conceptsr1 0.42))
+           (<= (concept-robustness cpt conceptsr1 0.13) 1)))
+    
+    (with-testing-data [cpt conceptsr2]
+      (= (concept-robustness cpt conceptsr2 (/ 1 2)) (concept-stability rctx2 cpt)))))
+
+;;;
+nil

--- a/src/test/clojure/conexp/fca/more_test.clj
+++ b/src/test/clojure/conexp/fca/more_test.clj
@@ -157,4 +157,21 @@
       (= (concept-robustness cpt conceptsr2 (/ 1 2)) (concept-stability rctx2 cpt)))))
 
 ;;;
+
+(deftest test-average-concept-robustness
+  (let [ctx1 (make-context-from-matrix 3 3
+                                    [0 0 1
+                                     1 0 1
+                                     1 1 0])]
+    (is (= (average-concept-robustness (concepts ctx1) 0.5) 0.5))
+    (is (= (average-concept-robustness (concepts ctx1) (/ 1 3)) (/ 10 27))))
+  
+  (with-testing-data [ctx (random-contexts 5 8)]
+    (let [cpts (concepts ctx)]
+      (= (average-concept-robustness cpts (/ 1 2)) 
+         (/ (reduce (fn [y cpt] (+ y (concept-stability ctx cpt))) 0 cpts)
+            (count cpts))))))
+
+
+;;;
 nil

--- a/src/test/clojure/conexp/math/util_test.clj
+++ b/src/test/clojure/conexp/math/util_test.clj
@@ -16,6 +16,16 @@
   (is (= 2203961430
          (binomial-coefficient 34 18))))
 
+(deftest test-eval-polynomial
+  (is (= 100
+         (eval-polynomial
+           (take 100 (repeat 1))
+           1)))
+  (is (= 3.0 (eval-polynomial [3] 0.42)))
+  (let [polynomial [3 2 1 5]]
+    (is (= (/ 39 8) (eval-polynomial polynomial (/ 1 2))))
+    (is (= 3.48 (eval-polynomial polynomial 0.2)))))
+
 ;;;
 
 nil


### PR DESCRIPTION
Dear exot,

In misc.clj, i`ve added the functionality to compute the robustness of concepts.
It is also possible to compute the average-concept-robustness of all concepts of a context.

I`ve also added a file socialanalytics.clj, which, right now, allows to:
-Compute the average-shortest-path of the following graphs for a given context:
  1.) The one which has as verticies the objects and the attributes and as edges the incidents.
   2.) The one which has as verticies the objects and in which two objects share an edge if they
       share an attribute.
   3.) The one which has as verticies the attributes and in which two attributes share an edge if they
       share an object.
-Compute the vertice-degrees of the same graphs as above.
For all those functions tests are implemented. I tried to stick to the style of the already existing tests.

Sincerly,
Kama93