### PR TITLE
Socialanalytics

### DIFF
--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -52,19 +52,30 @@
                                  (map #(take (- n %) (repeat 0))
                                       (range 0 n)))))))
 
-(defn- compute-row-for-object-or-attribute-matrix
-  "Tis is a helper-function to initialize the adjacency-matrix
-  for the object- and attribute-projection.
-  This function takes the derivation `object-or-attribute-derivation' of
-  an object or attribute x1 and a seq `object-or-attribute-derivations'
-  of derivations of objects or attributes to decide which objects
-  or attributes of the seq share an edge with x1."
-  [object-or-attribute-derivation object-or-attribute-derivations]
-  (mapv
-    #(let [sharedthings
-           (intersection object-or-attribute-derivation %)]
-       (if (empty? sharedthings) 0 1))
-    object-or-attribute-derivations))
+(defn- general-adjacency-matrix
+  "This is a helper function to compute the adjacency matricies of the object- and 
+  the attribute-projection.
+
+  Computes the upper half of the adjacency matrix of the undirected graph
+  with the nodeset `nodeset' and in which two nodes n1, n2 share an edge if
+  the intersection of (derivation `context' n1) and (derivation `context' n2)
+  is not empty."
+  ^"[[I" [context derivation nodeset]
+  (let [derivations (mapv
+                      #(derivation context #{%})
+                      nodeset)
+        n (count derivations)
+        compute-row  (fn [dev devs] (mapv
+                                      #(let [sharedthings
+                                             (intersection dev %)]
+                                         (if (empty? sharedthings) 0 1))
+                                      devs))]
+    (into-array
+      (map int-array (map
+                       #(compute-row
+                          (nth derivations %)
+                          (drop % derivations))
+                       (range 0 n))))))
 
 (defn object-projection-adjacency-matrix
   "Computes the adjacency-matrix for the graph, which has
@@ -73,16 +84,7 @@
   The edges of the graph have no direction, therefore just
   the upper entrys a_ij with i<=j have to be stored."
   ^"[[I" [context]
-  (let [object-derivations-of-context (mapv
-                                        #(object-derivation context #{%})
-                                        (objects context))
-        n (count object-derivations-of-context)]
-    (into-array
-      (map int-array (map
-                       #(compute-row-for-object-or-attribute-matrix
-                          (nth object-derivations-of-context %)
-                          (drop % object-derivations-of-context))
-                       (range 0 n))))))
+  (general-adjacency-matrix context object-derivation (objects context)))
 
 (defn attribute-projection-adjacency-matrix
   "Computes the adjacency-matrix for the graph, which has
@@ -91,15 +93,7 @@
   The edges of the graph have no direction, therefore just the upper
   entrys a_ij with i<=j have to be stored"
   ^"[[I"[context]
-  (let [attribute-derivations-of-context (mapv
-                                           #(attribute-derivation context #{%})
-                                           (attributes context))
-        n (count attribute-derivations-of-context)]
-    (into-array (map int-array (map
-                                 #(compute-row-for-object-or-attribute-matrix
-                                    (nth attribute-derivations-of-context %)
-                                    (drop % attribute-derivations-of-context))
-                                 (range 0 n))))))
+  (general-adjacency-matrix context attribute-derivation (attributes context)))
 
 ;;; Functions to compute adjacency-maps.
 ;;; The following functions take a context as argument and return

--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -21,7 +21,7 @@
 
 (defn adjacency-matrix-for-object-and-attribute-projection
   "Computes the adjacency-matrix of the graph which has the objects and 
-  attributes as verticies and the edges defined via the incidence-relation.
+  attributes as vertices and the edges defined via the incidence-relation.
   The edges of the graph have no direction, therefore just the upper entrys
   a_ij with i<=j have to be stored."
   [context]
@@ -68,7 +68,7 @@
 
 (defn adjacency-matrix-for-object-projection
   "Computes the adjacency-matrix for the graph, which has
-  the objects of a `context' as verticies and in which two
+  the objects of a `context' as vertices and in which two
   objects share an edge if they share an attribute.
   The edges of the graph have no direction, therefore just
   the upper entrys a_ij with i<=j have to be stored."
@@ -85,7 +85,7 @@
 
 (defn adjacency-matrix-for-attribute-projection
   "Computes the adjacency-matrix for the graph, which has
-  the attributes of a `context' as verticies and in which two attributes
+  the attributes of a `context' as vertices and in which two attributes
   share an edge if they share an object.
   The edges of the graph have no direction, therefore just the upper
   entrys a_ij with i<=j have to be stored"
@@ -107,19 +107,19 @@
 
 (defn object-and-attribute-projection
   "Computes for a given `context' the adjacency-map
-  of the graph, which has as verticies the objects
+  of the graph, which has as vertices the objects
   and attributes and in which the edges are defined
   through the incidence-relation.
   As it is possible for an object and an attribute
-  to have the same name, the verticies belonging to objects
+  to have the same name, the vertices belonging to objects
   are renamed from object1, object2 to
-  obj-object1, obj-object2,... and verticies belonging to
+  obj-object1, obj-object2,... and vertices belonging to
   attributes are renamed from attribute1,attribute2 to
   atr-attribute1,atr-attribute2..."
   [context]
   (let [object-nodes
         ;; Computes the successors
-        ;; for all verticies, which
+        ;; for all vertices, which
         ;; correspond to objects.
         (reduce
           (fn [hmap obj]
@@ -132,7 +132,7 @@
           (objects context))
         attribute-nodes
         ;; Computes the successors
-        ;; for all verticies, which
+        ;; for all vertices, which
         ;; correspond to attributes.
         (reduce
           (fn [hmap atr]
@@ -165,14 +165,14 @@
 
 (defn object-projection
   "Computes for a `context' the adjacency-map
-  of the graph which has as verticies
+  of the graph which has as vertices
   the objects of a context and in which
   two objects share an edge if they share an
   attribute."
   [context]
-  (let [init-verticies
+  (let [init-vertices
         ;; We initialize all objects
-        ;; of the context as verticies
+        ;; of the context as vertices
         ;; without edges.
         (reduce
           (fn [hmap object]
@@ -185,19 +185,19 @@
     (reduce
       (fn [hmap attribute]
         (add-edges hmap (attribute-derivation context #{attribute})))
-      init-verticies
+      init-vertices
       (attributes context))))
 
 (defn attribute-projection
   "Computes for a `context' the adjacency-map
-  of the graph which has as verticies
+  of the graph which has as vertices
   the attributes of a context and in which
   two attributes share an edge if they share an
   object."
   [context]
-  (let [init-verticies
+  (let [init-vertices
         ;; We initialize all attributes
-        ;; of the context as verticies
+        ;; of the context as vertices
         ;; without edges.
         (reduce
           (fn [hmap attribute]
@@ -210,7 +210,7 @@
     (reduce
       (fn [hmap object]
         (add-edges hmap (object-derivation context #{object})))
-      init-verticies
+      init-vertices
       (objects context))))
 
 ;;; Average-shortest-path
@@ -248,7 +248,7 @@
   with one modification: Because the graph is undirected, just the upper triangle
   (including diagonal-elements) of the adjacency-matrix
   has to be stored.
-  Paths from a vertice to itself are discarded. 
+  Paths from a vertex to itself are discarded. 
   If there are no edges and therefore no paths
   in the graph, nil is returned."
   [context projection]
@@ -266,9 +266,9 @@
                       (recur k (inc i) (inc i) matrix))
                     (recur (inc k) 0 0 matrix))
                   ;;If we are finished, we discard all
-                  ;; entrys of length 0 (they stand for verticies
+                  ;; entrys of length 0 (they stand for vertices
                   ;; which are not connected!) and all shortest-path-lengths
-                  ;; of a vertice to itself.
+                  ;; of a vertex to itself.
                   (remove zero?
                           (mapcat
                             #(drop 1 %)
@@ -279,50 +279,50 @@
 
 (defn average-shortest-path-objects-and-attributes
   "Computes for a `context' the average-shortest-path of the graph,
-   which has as verticies the objects and attributes of the context
+   which has as vertices the objects and attributes of the context
    and in which the edges are defined through the incidence-relation."
   [context]
   (average-shortest-path context adjacency-matrix-for-object-and-attribute-projection))
 
 (defn average-shortest-path-objects
   "Computes fo a `context' the average-shortest-path of the graph,
-   which has as verticies the objects of the context and in which
+   which has as vertices the objects of the context and in which
    two objects share an edge if they share an attribute."
   [context]
   (average-shortest-path context adjacency-matrix-for-object-projection))
 
 (defn average-shortest-path-attributes
   "Computes for a `context' the average-shortest-path of the graph,
-   which has as verticies the attributes of the context and in which
+   which has as vertices the attributes of the context and in which
    two attributes share an edge if they share an object."
   [context]
   (average-shortest-path context adjacency-matrix-for-attribute-projection))
 
-;;;Vertice-degrees
+;;;vertex-degrees
 
-(defn vertice-degrees
+(defn vertex-degrees
   "For a given `context' and a `projection', which maps
   contexts to graphs, represented by adjacency-maps,
-  the seq of vertice-degrees of (projection context) is returned."
+  the seq of vertex-degrees of (projection context) is returned."
   [context projection]
   (assert (context? context) "First argument must be a formal context!")
   (map
     count
     (vals (projection context))))
 
-(defn vertice-degrees-objects-and-attributes
-  "For a given `context', the seq of vertice-degrees
-  of the graph, which has as verticies the objects
+(defn vertex-degrees-objects-and-attributes
+  "For a given `context', the seq of vertex-degrees
+  of the graph, which has as vertices the objects
   and attributes of the context and in which the edges
   are defined through the incidence-relation, is returned."
   [context]
   ;; Note that this function does not use
-  ;; the above vertice-degrees function
+  ;; the above vertex-degrees function
   ;; for airbitary projections.
   ;; The reason therefore is,
   ;; that the special construction of
   ;; this specific graph allows to directly
-  ;; compute the list of the vertice-degrees
+  ;; compute the list of the vertex-degrees
   ;; from the context.
   (assert (context? context) "Argument must be a formal context!")
   (concat
@@ -333,23 +333,23 @@
       #(count (attribute-derivation context #{%}))
       (attributes context))))
 
-(defn vertice-degrees-objects
+(defn vertex-degrees-objects
   "For a given `context', this function returns
-  the vertice-degrees of the graph, which has
-  as verticies the objects of the context
+  the vertex-degrees of the graph, which has
+  as vertices the objects of the context
   and in which two objects share an edge if they share
   an attribute."
   [context]
-  (vertice-degrees context object-projection))
+  (vertex-degrees context object-projection))
 
-(defn vertice-degrees-attributes
+(defn vertex-degrees-attributes
   "For a given `context', this function returns
-  the vertice-degrees of the graph, which has
-  as verticies the attributes of the context and
+  the vertex-degrees of the graph, which has
+  as vertices the attributes of the context and
   in which two attributes share an edge if they share
   an object."
   [context]
-  (vertice-degrees context attribute-projection))
+  (vertex-degrees context attribute-projection))
 
 ;;;
 nil

--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -1,0 +1,98 @@
+;; Copyright ⓒ the conexp-clj developers; all rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file LICENSE at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns conexp.fca.applications.socialanalytics
+  "Provides some functionallity for Socialanalytics."
+  (:require [conexp.fca.contexts :refer :all]
+            [clojure.set :refer [intersection]]))
+
+;;;;Functions to compute adjacency-matricies
+
+(defn adjacency-matrix-for-object-and-attribute-projection
+  "Computes the adjacency-matrix of the graph which has the objects and 
+  attributes as verticies and the edges defined via the incidence-relation.
+  The edges of the graph have no direction, therefore just the upper entrys
+  a_ij with i<=j have to be stored."
+  [context]
+  (assert (context? context) "Argument must be a formal context!")
+  (let [objects (vec (objects context))
+        attributes (vec (attributes context))
+        m (count objects)
+        n (count attributes)
+        compute-row-for-object (fn [object attributes i]
+                                 ;; Computes for an `object' the row
+                                 ;; in the adjacency-matrix: Decides with which
+                                 ;; of the `attributes' the object has an edge with.
+                                 ;; Starts the row with `i' zeros.
+                                 (vec (concat (take i (repeat 0))
+                                              (map
+                                                (fn [attribute]
+                                                  (if (incident? context object attribute)
+                                                    1
+                                                    0))
+                                                attributes))))]
+    (vec (concat
+           ;; Concat the rows corresponding to an object...
+           (map #(compute-row-for-object (objects %)
+                                         attributes
+                                         (- m %))
+                (range 0 m))
+           ;; ... with the rows correpsonding to attributes.
+           (map #(vec (take (- n %) (repeat 0)))
+                (range 0 n))))))
+
+(defn- compute-row-for-object-or-attribute-matrix
+  "Tis is a helper-function to initialize the adjacency-matrix
+  for the object- and attribute-projection.
+  This function takes the derivation `object-or-attribute-derivation' of
+  an object or attribute x1 and a seq `object-or-attribute-derivations'
+  of derivations of objects or attributes to decide which objects
+  or attributes of the seq share an edge with x1."
+  [object-or-attribute-derivation object-or-attribute-derivations]
+  (mapv
+    #(let [sharedthings
+           (intersection object-or-attribute-derivation %)]
+       (if (empty? sharedthings) 0 1))
+    object-or-attribute-derivations))
+
+(defn adjacency-matrix-for-object-projection
+  "Computes the adjacency-matrix for the graph, which has
+  the objects of a `context' as verticies and in which two
+  objects share an edge if they share an attribute.
+  The edges of the graph have no direction, therefore just
+  the upper entrys a_ij with i<=j have to be stored."
+  [context]
+  (let [object-derivations-of-context (mapv
+                                        #(object-derivation context #{%})
+                                        (objects context))
+        n (count object-derivations-of-context)]
+    (mapv
+      #(compute-row-for-object-or-attribute-matrix
+         (nth object-derivations-of-context %)
+         (drop % object-derivations-of-context))
+      (range 0 n))))
+
+(defn adjacency-matrix-for-attribute-projection
+  "Computes the adjacency-matrix for the graph, which has
+  the attributes of a `context' as verticies and in which two attributes
+  share an edge if they share an object.
+  The edges of the graph have no direction, therefore just the upper
+  entrys a_ij with i<=j have to be stored"
+  [context]
+  (let [attribute-derivations-of-context (mapv
+                                           #(attribute-derivation context #{%})
+                                           (attributes context))
+        n (count attribute-derivations-of-context)]
+    (mapv
+      #(compute-row-for-object-or-attribute-matrix
+         (nth attribute-derivations-of-context %)
+         (drop % attribute-derivations-of-context))
+      (range 0 n))))
+
+;;;
+nil

--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -19,7 +19,7 @@
 
 ;;;;Functions to compute adjacency-matricies
 
-(defn adjacency-matrix-for-object-and-attribute-projection
+(defn combined-projection-adjacency-matrix
   "Computes the adjacency-matrix of the graph which has the objects and 
   attributes as vertices and the edges defined via the incidence-relation.
   The edges of the graph have no direction, therefore just the upper entrys
@@ -66,7 +66,7 @@
        (if (empty? sharedthings) 0 1))
     object-or-attribute-derivations))
 
-(defn adjacency-matrix-for-object-projection
+(defn object-projection-adjacency-matrix
   "Computes the adjacency-matrix for the graph, which has
   the objects of a `context' as vertices and in which two
   objects share an edge if they share an attribute.
@@ -83,7 +83,7 @@
          (drop % object-derivations-of-context))
       (range 0 n))))
 
-(defn adjacency-matrix-for-attribute-projection
+(defn attribute-projection-adjacency-matrix
   "Computes the adjacency-matrix for the graph, which has
   the attributes of a `context' as vertices and in which two attributes
   share an edge if they share an object.
@@ -105,7 +105,7 @@
 ;;; graphs, represented by adjacency-maps in the form
 ;;; {node1 set-of-neighbours, node2 set-of-neighbours...}.
 
-(defn object-and-attribute-projection
+(defn combined-projection
   "Computes for a given `context' the adjacency-map
   of the graph, which has as vertices the objects
   and attributes and in which the edges are defined
@@ -277,26 +277,26 @@
       nil
       (/ (reduce + paths) (count paths)))))
 
-(defn average-shortest-path-objects-and-attributes
+(defn combined-projection-average-shortest-path
   "Computes for a `context' the average-shortest-path of the graph,
    which has as vertices the objects and attributes of the context
    and in which the edges are defined through the incidence-relation."
   [context]
-  (average-shortest-path context adjacency-matrix-for-object-and-attribute-projection))
+  (average-shortest-path context combined-projection-adjacency-matrix))
 
-(defn average-shortest-path-objects
+(defn object-projection-average-shortest-path
   "Computes fo a `context' the average-shortest-path of the graph,
    which has as vertices the objects of the context and in which
    two objects share an edge if they share an attribute."
   [context]
-  (average-shortest-path context adjacency-matrix-for-object-projection))
+  (average-shortest-path context object-projection-adjacency-matrix))
 
-(defn average-shortest-path-attributes
+(defn attribute-projection-average-shortest-path
   "Computes for a `context' the average-shortest-path of the graph,
    which has as vertices the attributes of the context and in which
    two attributes share an edge if they share an object."
   [context]
-  (average-shortest-path context adjacency-matrix-for-attribute-projection))
+  (average-shortest-path context attribute-projection-adjacency-matrix))
 
 ;;;vertex-degrees
 
@@ -310,7 +310,7 @@
     count
     (vals (projection context))))
 
-(defn vertex-degrees-objects-and-attributes
+(defn combined-projection-vertex-degrees
   "For a given `context', the seq of vertex-degrees
   of the graph, which has as vertices the objects
   and attributes of the context and in which the edges
@@ -333,7 +333,7 @@
       #(count (attribute-derivation context #{%}))
       (attributes context))))
 
-(defn vertex-degrees-objects
+(defn object-projection-vertex-degrees
   "For a given `context', this function returns
   the vertex-degrees of the graph, which has
   as vertices the objects of the context
@@ -342,7 +342,7 @@
   [context]
   (vertex-degrees context object-projection))
 
-(defn vertex-degrees-attributes
+(defn attribute-projection-vertex-degrees
   "For a given `context', this function returns
   the vertex-degrees of the graph, which has
   as vertices the attributes of the context and

--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -293,5 +293,58 @@
   [context]
   (average-shortest-path context adjacency-matrix-for-attribute-projection))
 
+;;;Vertice-degrees
+
+(defn vertice-degrees
+  "For a given `context' and a `projection', which maps
+  contexts to graphs, represented by adjacency-maps,
+  the seq of vertice-degrees of (projection context) is returned."
+  [context projection]
+  (assert (context? context) "First argument must be a formal context!")
+  (map
+    count
+    (vals (projection context))))
+
+(defn vertice-degrees-objects-and-attributes
+  "For a given `context', the seq of vertice-degrees
+  of the graph, which has as verticies the objects
+  and attributes of the context and in which the edges
+  are defined through the incidence-relation, is returned."
+  [context]
+  ;; Note that this function does not use
+  ;; the above vertice-degrees function
+  ;; for airbitary projections.
+  ;; The reason therefore is,
+  ;; that the special construction of
+  ;; this specific graph allows to directly
+  ;; compute the list of the vertice-degrees
+  ;; from the context.
+  (assert (context? context) "Argument must be a formal context!")
+  (concat
+    (map
+      #(count (object-derivation context #{%}))
+      (objects context))
+    (map
+      #(count (attribute-derivation context #{%}))
+      (attributes context))))
+
+(defn vertice-degrees-objects
+  "For a given `context', this function returns
+  the vertice-degrees of the graph, which has
+  as verticies the objects of the context
+  and in which two objects share an edge if they share
+  an attribute."
+  [context]
+  (vertice-degrees context object-projection))
+
+(defn vertice-degrees-attributes
+  "For a given `context', this function returns
+  the vertice-degrees of the graph, which has
+  as verticies the attributes of the context and
+  in which two attributes share an edge if they share
+  an object."
+  [context]
+  (vertice-degrees context attribute-projection))
+
 ;;;
 nil

--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -8,7 +8,12 @@
 
 (ns conexp.fca.applications.socialanalytics
   "Provides some functionallity for Socialanalytics."
-  (:require [conexp.fca.contexts :refer :all]
+  (:require [conexp.fca.contexts :refer [objects
+                                         attributes
+                                         object-derivation
+                                         attribute-derivation
+                                         context?
+                                         incident?]]
             [clojure.set :refer [intersection
                                  union]]))
 

--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -94,5 +94,90 @@
          (drop % attribute-derivations-of-context))
       (range 0 n))))
 
+;;; Average-shortest-path
+
+(defn- floyd-step
+  "This is a helper-function for average-shortest-path:
+  Do one overwriting in the floyd-algorithm, see
+  https://de.wikipedia.org/wiki/Algorithmus_von_Floyd_und_Warshall or
+  https://en.wikipedia.org/wiki/Floyd-Warshall_algorithm for Details."
+  [matrix k i j]
+  (assert (<= i j) "No computation under the diagonalelements possible!")
+  (let [A_ij (nth (nth matrix i) (- j i))
+        A_ik (if (<= i k)
+               (nth (nth matrix i) (- k i))
+               (nth (nth matrix k) (- i k)))
+        A_kj (if (<= k j)
+               (nth (nth matrix k) (- j k))
+               (nth (nth matrix j) (- k j)))
+        newvalue (cond
+                   (and (= A_ij 0) (or (= A_ik 0) (=  A_kj 0))) 0
+                   (= A_ij 0) (+ A_ik A_kj)
+                   (or (= A_ik 0) (=  A_kj 0)) A_ij
+                   :else (min A_ij (+ A_ik A_kj)))]
+    (assoc matrix
+           i
+           (assoc (nth matrix i) (- j i) newvalue))))
+
+(defn average-shortest-path
+  "Computes the average-shortest path for a given `context' and a `projection'.
+  The projection f should map a context to the upper half of the adjacency-matrix
+  of the corresponding undirected graph.
+  To compute the path-lenghts, the floyd-algorithm:
+  https://de.wikipedia.org/wiki/Algorithmus_von_Floyd_und_Warshall,
+  https://en.wikipedia.org/wiki/Floyd-Warshall_algorithm is used
+  with one modification: Because the graph is undirected, just the upper triangle
+  (including diagonal-elements) of the adjacency-matrix
+  has to be stored.
+  Paths from a vertice to itself are discarded. 
+  If there are no edges and therefore no paths
+  in the graph, nil is returned."
+  [context projection]
+  (assert (context? context) "Argument is not a formal context!")
+  (let [matrix (projection context)
+        n (count matrix)
+        paths (loop [k 0
+                     i 0
+                     j 0
+                     matrix matrix]
+                (if (< k n)
+                  (if (< i n)
+                    (if (< j n)
+                      (recur k i (inc j) (floyd-step matrix k i j))
+                      (recur k (inc i) (inc i) matrix))
+                    (recur (inc k) 0 0 matrix))
+                  ;;If we are finished, we discard all
+                  ;; entrys of length 0 (they stand for verticies
+                  ;; which are not connected!) and all shortest-path-lengths
+                  ;; of a vertice to itself.
+                  (remove zero?
+                          (mapcat
+                            #(drop 1 %)
+                            matrix))))]
+    (if (empty? paths)
+      nil
+      (/ (reduce + paths) (count paths)))))
+
+(defn average-shortest-path-objects-and-attributes
+  "Computes for a `context' the average-shortest-path of the graph,
+   which has as verticies the objects and attributes of the context
+   and in which the edges are defined through the incidence-relation."
+  [context]
+  (average-shortest-path context adjacency-matrix-for-object-and-attribute-projection))
+
+(defn average-shortest-path-objects
+  "Computes fo a `context' the average-shortest-path of the graph,
+   which has as verticies the objects of the context and in which
+   two objects share an edge if they share an attribute."
+  [context]
+  (average-shortest-path context adjacency-matrix-for-object-projection))
+
+(defn average-shortest-path-attributes
+  "Computes for a `context' the average-shortest-path of the graph,
+   which has as verticies the attributes of the context and in which
+   two attributes share an edge if they share an object."
+  [context]
+  (average-shortest-path context adjacency-matrix-for-attribute-projection))
+
 ;;;
 nil

--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -9,7 +9,8 @@
 (ns conexp.fca.applications.socialanalytics
   "Provides some functionallity for Socialanalytics."
   (:require [conexp.fca.contexts :refer :all]
-            [clojure.set :refer [intersection]]))
+            [clojure.set :refer [intersection
+                                 union]]))
 
 ;;;;Functions to compute adjacency-matricies
 
@@ -93,6 +94,119 @@
          (nth attribute-derivations-of-context %)
          (drop % attribute-derivations-of-context))
       (range 0 n))))
+
+;;; Functions to compute adjacency-maps.
+;;; The following functions take a context as argument and return
+;;; graphs, represented by adjacency-maps in the form
+;;; {node1 set-of-neighbours, node2 set-of-neighbours...}.
+
+(defn object-and-attribute-projection
+  "Computes for a given `context' the adjacency-map
+  of the graph, which has as verticies the objects
+  and attributes and in which the edges are defined
+  through the incidence-relation.
+  As it is possible for an object and an attribute
+  to have the same name, the verticies belonging to objects
+  are renamed from object1, object2 to
+  obj-object1, obj-object2,... and verticies belonging to
+  attributes are renamed from attribute1,attribute2 to
+  atr-attribute1,atr-attribute2..."
+  [context]
+  (let [object-nodes
+        ;; Computes the successors
+        ;; for all verticies, which
+        ;; correspond to objects.
+        (reduce
+          (fn [hmap obj]
+            (assoc hmap (str 'obj- obj) 
+                   (set
+                     (map
+                       #(str 'atr- %)
+                       (object-derivation context #{obj})))))
+          {}
+          (objects context))
+        attribute-nodes
+        ;; Computes the successors
+        ;; for all verticies, which
+        ;; correspond to attributes.
+        (reduce
+          (fn [hmap atr]
+            (assoc hmap (str 'atr- atr)
+                   (set
+                     (map
+                       #(str 'obj- %)
+                       (attribute-derivation context #{atr})))))
+          {}
+          (attributes context))]
+    (merge object-nodes attribute-nodes)))
+
+(defn- add-edges
+  "This is a helper-function to compute
+  the objects-projection and the attributes-projection
+  of a context.
+
+  It takes a map `hmap' and a `set' and adds all elements
+  of set to all those keys of hmap, whose are elements of
+  set themselves."
+  [hmap set]
+  (reduce
+    (fn [currenthmap element]
+      (update-in currenthmap
+                 [element]
+                 union
+                 set))
+    hmap
+    set))
+
+(defn object-projection
+  "Computes for a `context' the adjacency-map
+  of the graph which has as verticies
+  the objects of a context and in which
+  two objects share an edge if they share an
+  attribute."
+  [context]
+  (let [init-verticies
+        ;; We initialize all objects
+        ;; of the context as verticies
+        ;; without edges.
+        (reduce
+          (fn [hmap object]
+            (assoc hmap object #{}))
+          {}
+          (objects context))]
+    ;; Iterate through all attributes `attribute' to
+    ;; add the edges o1<->02 for all objects
+    ;; o1,o2 that have the `attribute'.
+    (reduce
+      (fn [hmap attribute]
+        (add-edges hmap (attribute-derivation context #{attribute})))
+      init-verticies
+      (attributes context))))
+
+(defn attribute-projection
+  "Computes for a `context' the adjacency-map
+  of the graph which has as verticies
+  the attributes of a context and in which
+  two attributes share an edge if they share an
+  object."
+  [context]
+  (let [init-verticies
+        ;; We initialize all attributes
+        ;; of the context as verticies
+        ;; without edges.
+        (reduce
+          (fn [hmap attribute]
+            (assoc hmap attribute #{}))
+          {}
+          (attributes context))]
+    ;; Iterate through all objects `object' to
+    ;; add the edges a1<->a2 for all attributes
+    ;; a1,a2 that this `object' has.
+    (reduce
+      (fn [hmap object]
+        (add-edges hmap (object-derivation context #{object})))
+      init-verticies
+      (objects context))))
 
 ;;; Average-shortest-path
 

--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -238,8 +238,8 @@
     (two-dimensional-aset matrix i (- j i) newvalue)))
 
 (defn distance-matrix
-  "Computes the distance-matrix for a given `context' and a `projection'.
-  The projection should map a context to the upper half of the adjacency matrix
+  "Computes the distance-matrix for a given `context' and a function `fn'.
+  `fn' should map a context to the upper half of the adjacency matrix
   of the corresponding undirected graph.
   To compute the path-lenghts, the floyd-algorithm:
   https://de.wikipedia.org/wiki/Algorithmus_von_Floyd_und_Warshall,
@@ -247,9 +247,9 @@
   with one modification: Because the graph is undirected, just the upper triangle
   (including diagonal-elements) of the adjacency matrix
   has to be stored."
-  ^"[[I" [context projection]
+  ^"[[I" [context fn]
   (assert (context? context) "Fist argument must be a formal context")
-  (let [^"[[I" matrix (projection context)
+  (let [^"[[I" matrix (fn context)
         n (count matrix)]
     (do (dorun
           (for [k (range 0 n) i (range 0 n) j (range i n)]
@@ -306,14 +306,14 @@
 ;;;Vertex-degrees
 
 (defn vertex-degrees
-  "For a given `context' and a `projection', which maps
+  "For a given `context' and a function `fn', which maps
   contexts to graphs, represented by adjacency maps,
   the seq of vertex degrees of (projection context) is returned."
-  [context projection]
+  [context fn]
   (assert (context? context) "First argument must be a formal context!")
   (map
     count
-    (vals (projection context))))
+    (vals (fn context))))
 
 (defn context-graph-vertex-degrees
   "For a given `context', the seq of vertex degrees

--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -19,7 +19,7 @@
 
 ;;;;Functions to compute adjacency-matricies
 
-(defn combined-projection-adjacency-matrix
+(defn context-graph-adjacency-matrix
   "Computes the adjacency matrix of the graph which has the objects and 
   attributes as vertices and the edges defined via the incidence-relation.
   The edges of the graph have no direction, therefore just the upper entrys
@@ -99,7 +99,7 @@
 ;;; graphs, represented by adjacency-maps in the form
 ;;; {node1 set-of-neighbours, node2 set-of-neighbours...}.
 
-(defn combined-projection
+(defn context-graph
   "Computes for a given `context' the adjacency map
   of the graph, which has as vertices the objects
   and attributes and in which the edges are defined
@@ -276,14 +276,14 @@
     nil
     (/ (reduce + distances) (count distances)))))
 
-(defn combined-projection-average-shortest-path
+(defn context-graph-average-shortest-path
   "Computes for a `context' the average shortest path lenght of the graph,
    which has as vertices the objects and attributes of the context
    and in which the edges are defined through the incidence-relation."
   [context]
   (assert (context? context) "Argument must be a formal context!")
   (average-shortest-path (distance-matrix context
-                                          combined-projection-adjacency-matrix)))
+                                          context-graph-adjacency-matrix)))
 
 (defn object-projection-average-shortest-path
   "Computes fo a `context' the average shortest path length of the graph,
@@ -315,7 +315,7 @@
     count
     (vals (projection context))))
 
-(defn combined-projection-vertex-degrees
+(defn context-graph-vertex-degrees
   "For a given `context', the seq of vertex degrees
   of the graph, which has as vertices the objects
   and attributes of the context and in which the edges

--- a/src/main/clojure/conexp/fca/applications/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/socialanalytics.clj
@@ -20,12 +20,11 @@
 ;;;;Functions to compute adjacency-matricies
 
 (defn combined-projection-adjacency-matrix
-  "Computes the adjacency-matrix of the graph which has the objects and 
+  "Computes the adjacency matrix of the graph which has the objects and 
   attributes as vertices and the edges defined via the incidence-relation.
   The edges of the graph have no direction, therefore just the upper entrys
   a_ij with i<=j have to be stored."
   ^"[[I" [context]
-  (assert (context? context) "Argument must be a formal context!")
   (let [objects (vec (objects context))
         attributes (vec (attributes context))
         m (count objects)
@@ -53,17 +52,17 @@
                                       (range 0 n)))))))
 
 (defn- general-adjacency-matrix
-  "This is a helper function to compute the adjacency matricies of the object- and 
+  "This is a helper function to compute the adjacency matrices of the object- and 
   the attribute-projection.
 
   Computes the upper half of the adjacency matrix of the undirected graph
-  with the nodeset `nodeset' and in which two nodes n1, n2 share an edge if
+  with the node set `node-set' and in which two nodes n1, n2 share an edge if
   the intersection of (derivation `context' n1) and (derivation `context' n2)
   is not empty."
-  ^"[[I" [context derivation nodeset]
+  ^"[[I" [context derivation node-set]
   (let [derivations (mapv
                       #(derivation context #{%})
-                      nodeset)
+                      node-set)
         n (count derivations)
         compute-row  (fn [dev devs] (mapv
                                       #(let [sharedthings
@@ -78,7 +77,7 @@
                        (range 0 n))))))
 
 (defn object-projection-adjacency-matrix
-  "Computes the adjacency-matrix for the graph, which has
+  "Computes the adjacency matrix for the graph, which has
   the objects of a `context' as vertices and in which two
   objects share an edge if they share an attribute.
   The edges of the graph have no direction, therefore just
@@ -87,12 +86,12 @@
   (general-adjacency-matrix context object-derivation (objects context)))
 
 (defn attribute-projection-adjacency-matrix
-  "Computes the adjacency-matrix for the graph, which has
+  "Computes the adjacency matrix for the graph, which has
   the attributes of a `context' as vertices and in which two attributes
   share an edge if they share an object.
   The edges of the graph have no direction, therefore just the upper
   entrys a_ij with i<=j have to be stored"
-  ^"[[I"[context]
+  ^"[[I" [context]
   (general-adjacency-matrix context attribute-derivation (attributes context)))
 
 ;;; Functions to compute adjacency-maps.
@@ -101,7 +100,7 @@
 ;;; {node1 set-of-neighbours, node2 set-of-neighbours...}.
 
 (defn combined-projection
-  "Computes for a given `context' the adjacency-map
+  "Computes for a given `context' the adjacency map
   of the graph, which has as vertices the objects
   and attributes and in which the edges are defined
   through the incidence-relation.
@@ -150,8 +149,8 @@
   (derivation context #{c})."
   [context derivation node-set connection-set]
   (let [init-vertices
-        ;; We initialize all nodes
-        ;; of the context as verticies
+        ;; We initialize all elements
+        ;; of the `node-set' as verticies
         ;; without edges.
         (reduce
           (fn [hmap node]
@@ -175,7 +174,7 @@
             set))]
     ;; Iterate now through all elements `connection'
     ;; in connection-set to find the edges n1<->n2
-    ;; for all n1, n2 in (derivation context connection).
+    ;; for all n1, n2 in (derivation context #{connection}).
     (reduce
       (fn [hmap connection]
         (add-edges hmap (derivation context #{connection})))
@@ -183,7 +182,7 @@
       connection-set)))
 
 (defn object-projection
-  "Computes for a `context' the adjacency-map
+  "Computes for a `context' the adjacency map
   of the graph which has as vertices
   the objects of a context and in which
   two objects share an edge if they share an
@@ -195,7 +194,7 @@
                       (attributes context)))
 
 (defn attribute-projection
-  "Computes for a `context' the adjacency-map
+  "Computes for a `context' the adjacency map
   of the graph which has as vertices
   the attributes of a context and in which
   two attributes share an edge if they share an
@@ -240,17 +239,14 @@
 
 (defn distance-matrix
   "Computes the distance-matrix for a given `context' and a `projection'.
-  The projection f should map a context to the upper half of the adjacency-matrix
+  The projection should map a context to the upper half of the adjacency matrix
   of the corresponding undirected graph.
   To compute the path-lenghts, the floyd-algorithm:
   https://de.wikipedia.org/wiki/Algorithmus_von_Floyd_und_Warshall,
   https://en.wikipedia.org/wiki/Floyd-Warshall_algorithm is used
   with one modification: Because the graph is undirected, just the upper triangle
-  (including diagonal-elements) of the adjacency-matrix
-  has to be stored.
-  Paths from a vertex to itself are discarded. 
-  If there are no edges and therefore no paths
-  in the graph, nil is returned."
+  (including diagonal-elements) of the adjacency matrix
+  has to be stored."
   ^"[[I" [context projection]
   (assert (context? context) "Fist argument must be a formal context")
   (let [^"[[I" matrix (projection context)
@@ -261,8 +257,8 @@
       matrix)))
 
 (defn average-shortest-path
-  "Takes the upper half of a distance-matrix `matrix' and computes the average-shortest-path
-  of the corresponding undirected graph.
+  "Takes the upper half of a distance-matrix `matrix' and computes the average shortest
+  path lenght of the corresponding undirected graph.
   To compute the path-lenghts, the floyd-algorithm:
   https://de.wikipedia.org/wiki/Algorithmus_von_Floyd_und_Warshall,
   https://en.wikipedia.org/wiki/Floyd-Warshall_algorithm is used
@@ -281,35 +277,38 @@
     (/ (reduce + distances) (count distances)))))
 
 (defn combined-projection-average-shortest-path
-  "Computes for a `context' the average-shortest-path of the graph,
+  "Computes for a `context' the average shortest path lenght of the graph,
    which has as vertices the objects and attributes of the context
    and in which the edges are defined through the incidence-relation."
   [context]
+  (assert (context? context) "Argument must be a formal context!")
   (average-shortest-path (distance-matrix context
                                           combined-projection-adjacency-matrix)))
 
 (defn object-projection-average-shortest-path
-  "Computes fo a `context' the average-shortest-path of the graph,
+  "Computes fo a `context' the average shortest path length of the graph,
    which has as vertices the objects of the context and in which
    two objects share an edge if they share an attribute."
   [context]
+  (assert (context? context) "Argument must be a formal context!")
   (average-shortest-path (distance-matrix context
                                           object-projection-adjacency-matrix)))
 
 (defn attribute-projection-average-shortest-path
-  "Computes for a `context' the average-shortest-path of the graph,
+  "Computes for a `context' the average shortest path length of the graph,
    which has as vertices the attributes of the context and in which
    two attributes share an edge if they share an object."
   [context]
+  (assert (context? context) "Argument must be a formal context!")
   (average-shortest-path (distance-matrix context
                                           attribute-projection-adjacency-matrix)))
 
-;;;vertex-degrees
+;;;Vertex-degrees
 
 (defn vertex-degrees
   "For a given `context' and a `projection', which maps
-  contexts to graphs, represented by adjacency-maps,
-  the seq of vertex-degrees of (projection context) is returned."
+  contexts to graphs, represented by adjacency maps,
+  the seq of vertex degrees of (projection context) is returned."
   [context projection]
   (assert (context? context) "First argument must be a formal context!")
   (map
@@ -317,10 +316,10 @@
     (vals (projection context))))
 
 (defn combined-projection-vertex-degrees
-  "For a given `context', the seq of vertex-degrees
+  "For a given `context', the seq of vertex degrees
   of the graph, which has as vertices the objects
   and attributes of the context and in which the edges
-  are defined through the incidence-relation, is returned."
+  are defined through the incidence relation, is returned."
   [context]
   ;; Note that this function does not use
   ;; the above vertex-degrees function
@@ -328,7 +327,7 @@
   ;; The reason therefore is,
   ;; that the special construction of
   ;; this specific graph allows to directly
-  ;; compute the list of the vertex-degrees
+  ;; compute the list of the vertex degrees
   ;; from the context.
   (assert (context? context) "Argument must be a formal context!")
   (concat
@@ -341,7 +340,7 @@
 
 (defn object-projection-vertex-degrees
   "For a given `context', this function returns
-  the vertex-degrees of the graph, which has
+  the vertex degrees of the graph, which has
   as vertices the objects of the context
   and in which two objects share an edge if they share
   an attribute."
@@ -350,7 +349,7 @@
 
 (defn attribute-projection-vertex-degrees
   "For a given `context', this function returns
-  the vertex-degrees of the graph, which has
+  the vertex degrees of the graph, which has
   as vertices the attributes of the context and
   in which two attributes share an edge if they share
   an object."

--- a/src/test/clojure/conexp/fca/applications/socialanalytics_test.clj
+++ b/src/test/clojure/conexp/fca/applications/socialanalytics_test.clj
@@ -18,7 +18,7 @@
 
 ;Average-shortest-path
 
-(deftest test-average-shortest-path-objects-and-attributes
+(deftest test-combined-projection-average-shortest-path
   (let [ctx (make-context-from-matrix 4 3
                           [1 0 1
                            0 1 0
@@ -28,12 +28,12 @@
                                 [0 0 0
                                  0 1 0
                                  1 0 1])]
-    (is (= (average-shortest-path-objects-and-attributes ctx) (/ 50 21)))
-    (is (= (average-shortest-path-objects-and-attributes ctx1) (/ 5 4)))
-    (is (= (average-shortest-path-objects-and-attributes (random-context 50 0)) nil)))
+    (is (= (combined-projection-average-shortest-path ctx) (/ 50 21)))
+    (is (= (combined-projection-average-shortest-path ctx1) (/ 5 4)))
+    (is (= (combined-projection-average-shortest-path (random-context 50 0)) nil)))
   
   (with-testing-data [ctx (random-contexts 5 50)]
-    (let [value (average-shortest-path-objects-and-attributes ctx)]
+    (let [value (combined-projection-average-shortest-path ctx)]
       (or (nil? value)
           (<= 1
               value
@@ -51,18 +51,18 @@
                                         1 1 0
                                         0 1 1
                                         0 0 1])]
-    (is (= (average-shortest-path-objects ctx) 1))
-    (is (= (average-shortest-path-objects ctx1) (/ 13 10)))
-    (is (nil? (average-shortest-path-objects (random-context 50 0)))))
+    (is (= (object-projection-average-shortest-path ctx) 1))
+    (is (= (object-projection-average-shortest-path ctx1) (/ 13 10)))
+    (is (nil? (object-projection-average-shortest-path (random-context 50 0)))))
   
   (with-testing-data [ctx (random-contexts 5 60)]
-    (let [value (average-shortest-path-objects ctx)]
+    (let [value (object-projection-average-shortest-path ctx)]
       (or (nil? value)
           (<= 1
               value
               (count (objects ctx)))))))
 
-(deftest test-average-shortest-path-attributes
+(deftest test-attribute-projection-average-shortest-path
   (let [ctx (make-context-from-matrix 4 5
                                       [1 0 1 1 0
                                        0 1 1 0 0
@@ -73,18 +73,18 @@
                                        1 1 0 0
                                        0 1 1 0
                                        0 0 1 1])]
-    (is (= (average-shortest-path-attributes ctx) (/ 7 5)))
-    (is (= (average-shortest-path-attributes ctx1) (/ 5 3)))
-    (is (nil? (average-shortest-path-attributes (random-context 60 0)))))
+    (is (= (attribute-projection-average-shortest-path ctx) (/ 7 5)))
+    (is (= (attribute-projection-average-shortest-path ctx1) (/ 5 3)))
+    (is (nil? (attribute-projection-average-shortest-path (random-context 60 0)))))
   
   (with-testing-data [ctx (random-contexts 7 50)]
-    (let [value (average-shortest-path-attributes ctx)]
+    (let [value (attribute-projection-average-shortest-path ctx)]
           (or (nil? value)
               (<= 1
                   value
                   (count (attributes ctx)))))))
 
-(deftest test-vertex-degrees
+(deftest test-combined-projection-vertex-degrees
   (let [ctx (make-context-from-matrix 5 3
                                       [1 1 0
                                        0 1 0
@@ -96,19 +96,19 @@
                                         0 1 1
                                         1 0 0
                                         0 1 0])]
-    (is (= (sort (vertex-degrees-objects-and-attributes ctx))
+    (is (= (sort (combined-projection-vertex-degrees ctx))
            '(1 1 2 2 2 2 3 3)))
-    (is (= (sort (vertex-degrees-objects-and-attributes ctx1))
+    (is (= (sort (combined-projection-vertex-degrees ctx1))
            '(1 1 1 2 2 2 3))))
   
   (with-testing-data [ctx (random-contexts 7 150)]
-                     (let [degrees (vertex-degrees-objects-and-attributes ctx)
+                     (let [degrees (combined-projection-vertex-degrees ctx)
                            m (count (objects ctx))
                            n (count (attributes ctx))]
                        (and (= (count degrees) (+ m n))
                             (every? #(<= 0 % (max m n)) degrees)))))
 
-(deftest test-vertex-degrees-objects
+(deftest test-object-projection-vertex-degrees
   (let [ctx (make-context-from-matrix 5 3
                                       [1 1 0
                                        0 1 0
@@ -120,18 +120,18 @@
                                         0 1 1
                                         1 0 0
                                         0 1 0])]
-    (is (= (sort (vertex-degrees-objects ctx))
+    (is (= (sort (object-projection-vertex-degrees ctx))
            '(3 3 4 4 5)))
-    (is (= (sort (vertex-degrees-objects ctx1))
+    (is (= (sort (object-projection-vertex-degrees ctx1))
            '(2 3 3 4))))
   
   (with-testing-data [ctx (random-contexts 7 150)]
-                     (let [degrees (vertex-degrees-objects ctx)
+                     (let [degrees (object-projection-vertex-degrees ctx)
                            n (count (objects ctx))]
                        (and (= (count degrees) n)
                             (every? #(<= 0 % n) degrees)))))
 
-(deftest test-vertex-degrees-attributes
+(deftest test-attribute-projection-vertex-degrees
   (let [ctx (make-context-from-matrix 5 3
                                       [1 1 0
                                        0 1 0
@@ -142,13 +142,13 @@
                                        [1 0 0 1 0
                                         1 1 1 0 0
                                         0 0 0 1 0])]
-    (is (= (sort (vertex-degrees-attributes ctx))
+    (is (= (sort (attribute-projection-vertex-degrees ctx))
            '(3 3 3)))
-    (is (= (sort (vertex-degrees-attributes ctx1))
+    (is (= (sort (attribute-projection-vertex-degrees ctx1))
            '(0 2 3 3 4))))
   
   (with-testing-data [ctx (random-contexts 7 150)]
-                     (let [degrees (vertex-degrees-attributes ctx)
+                     (let [degrees (attribute-projection-vertex-degrees ctx)
                            n (count (attributes ctx))]
                        (and (= (count degrees) n)
                             (every? #(<= 0 % n) degrees)))))

--- a/src/test/clojure/conexp/fca/applications/socialanalytics_test.clj
+++ b/src/test/clojure/conexp/fca/applications/socialanalytics_test.clj
@@ -1,0 +1,157 @@
+;; Copyright ⓒ the conexp-clj developers; all rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file LICENSE at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns conexp.fca.applications.socialanalytics-test
+  (:require [conexp.fca.contexts :refer [random-context
+                                         random-contexts
+                                         make-context-from-matrix
+                                         objects
+                                         attributes]]
+          [conexp.fca.applications.socialanalytics :refer :all]
+          [clojure.test :refer [deftest is]]
+          [conexp.base :refer [with-testing-data]]))
+
+;Average-shortest-path
+
+(deftest test-average-shortest-path-objects-and-attributes
+  (let [ctx (make-context-from-matrix 4 3
+                          [1 0 1
+                           0 1 0
+                           1 0 0
+                           1 1 0])
+        ctx1 (make-context-from-matrix 3 3
+                                [0 0 0
+                                 0 1 0
+                                 1 0 1])]
+    (is (= (average-shortest-path-objects-and-attributes ctx) (/ 50 21)))
+    (is (= (average-shortest-path-objects-and-attributes ctx1) (/ 5 4)))
+    (is (= (average-shortest-path-objects-and-attributes (random-context 50 0)) nil)))
+  
+  (with-testing-data [ctx (random-contexts 5 50)]
+    (let [value (average-shortest-path-objects-and-attributes ctx)]
+      (or (nil? value)
+          (<= 1
+              value
+              (+ (count (objects ctx))
+                 (count (attributes ctx))))))))
+
+(deftest test-average-shortest-paths-objects
+  (let [ctx (make-context-from-matrix 3 3
+                               [1 0 0
+                                1 1 1
+                                0 0 0])
+        ctx1 (make-context-from-matrix ['a 'b 'c 'd 'e] ['a 'b 'c]
+                                       [1 0 1
+                                        0 1 0
+                                        1 1 0
+                                        0 1 1
+                                        0 0 1])]
+    (is (= (average-shortest-path-objects ctx) 1))
+    (is (= (average-shortest-path-objects ctx1) (/ 13 10)))
+    (is (nil? (average-shortest-path-objects (random-context 50 0)))))
+  
+  (with-testing-data [ctx (random-contexts 5 60)]
+    (let [value (average-shortest-path-objects ctx)]
+      (or (nil? value)
+          (<= 1
+              value
+              (count (objects ctx)))))))
+
+(deftest test-average-shortest-path-attributes
+  (let [ctx (make-context-from-matrix 4 5
+                                      [1 0 1 1 0
+                                       0 1 1 0 0
+                                       1 0 0 1 0
+                                       0 1 1 0 1])
+        ctx1 (make-context-from-matrix 4 4
+                                      [1 0 0 0
+                                       1 1 0 0
+                                       0 1 1 0
+                                       0 0 1 1])]
+    (is (= (average-shortest-path-attributes ctx) (/ 7 5)))
+    (is (= (average-shortest-path-attributes ctx1) (/ 5 3)))
+    (is (nil? (average-shortest-path-attributes (random-context 60 0)))))
+  
+  (with-testing-data [ctx (random-contexts 7 50)]
+    (let [value (average-shortest-path-attributes ctx)]
+          (or (nil? value)
+              (<= 1
+                  value
+                  (count (attributes ctx)))))))
+
+(deftest test-vertice-degrees
+  (let [ctx (make-context-from-matrix 5 3
+                                      [1 1 0
+                                       0 1 0
+                                       0 0 1
+                                       0 1 1
+                                       1 0 1])
+        ctx1 (make-context-from-matrix ['a, 'b, 'c, 'd] ['a, 'b, 'c]
+                                       [1 1 0
+                                        0 1 1
+                                        1 0 0
+                                        0 1 0])]
+    (is (= (sort (vertice-degrees-objects-and-attributes ctx))
+           '(1 1 2 2 2 2 3 3)))
+    (is (= (sort (vertice-degrees-objects-and-attributes ctx1))
+           '(1 1 1 2 2 2 3))))
+  
+  (with-testing-data [ctx (random-contexts 7 150)]
+                     (let [degrees (vertice-degrees-objects-and-attributes ctx)
+                           m (count (objects ctx))
+                           n (count (attributes ctx))]
+                       (and (= (count degrees) (+ m n))
+                            (every? #(<= 0 % (max m n)) degrees)))))
+
+(deftest test-vertice-degrees-objects
+  (let [ctx (make-context-from-matrix 5 3
+                                      [1 1 0
+                                       0 1 0
+                                       0 0 1
+                                       0 1 1
+                                       1 0 1])
+        ctx1 (make-context-from-matrix ['a, 'b, 'c, 'd] ['a, 'b, 'c]
+                                       [1 1 0
+                                        0 1 1
+                                        1 0 0
+                                        0 1 0])]
+    (is (= (sort (vertice-degrees-objects ctx))
+           '(3 3 4 4 5)))
+    (is (= (sort (vertice-degrees-objects ctx1))
+           '(2 3 3 4))))
+  
+  (with-testing-data [ctx (random-contexts 7 150)]
+                     (let [degrees (vertice-degrees-objects ctx)
+                           n (count (objects ctx))]
+                       (and (= (count degrees) n)
+                            (every? #(<= 0 % n) degrees)))))
+
+(deftest test-vertice-degrees-attributes
+  (let [ctx (make-context-from-matrix 5 3
+                                      [1 1 0
+                                       0 1 0
+                                       0 0 1
+                                       0 1 1
+                                       1 0 1])
+        ctx1 (make-context-from-matrix ['a, 'b, 'c] ['a, 'b, 'c, 'd, 'e]
+                                       [1 0 0 1 0
+                                        1 1 1 0 0
+                                        0 0 0 1 0])]
+    (is (= (sort (vertice-degrees-attributes ctx))
+           '(3 3 3)))
+    (is (= (sort (vertice-degrees-attributes ctx1))
+           '(0 2 3 3 4))))
+  
+  (with-testing-data [ctx (random-contexts 7 150)]
+                     (let [degrees (vertice-degrees-attributes ctx)
+                           n (count (attributes ctx))]
+                       (and (= (count degrees) n)
+                            (every? #(<= 0 % n) degrees)))))
+
+;;;
+nil

--- a/src/test/clojure/conexp/fca/applications/socialanalytics_test.clj
+++ b/src/test/clojure/conexp/fca/applications/socialanalytics_test.clj
@@ -18,7 +18,7 @@
 
 ;Average-shortest-path
 
-(deftest test-combined-projection-average-shortest-path
+(deftest test-context-graph-average-shortest-path
   (let [ctx (make-context-from-matrix 4 3
                           [1 0 1
                            0 1 0
@@ -28,12 +28,12 @@
                                 [0 0 0
                                  0 1 0
                                  1 0 1])]
-    (is (= (combined-projection-average-shortest-path ctx) (/ 50 21)))
-    (is (= (combined-projection-average-shortest-path ctx1) (/ 5 4)))
-    (is (= (combined-projection-average-shortest-path (random-context 50 0)) nil)))
+    (is (= (context-graph-average-shortest-path ctx) (/ 50 21)))
+    (is (= (context-graph-average-shortest-path ctx1) (/ 5 4)))
+    (is (= (context-graph-average-shortest-path (random-context 50 0)) nil)))
   
   (with-testing-data [ctx (random-contexts 5 50)]
-    (let [value (combined-projection-average-shortest-path ctx)]
+    (let [value (context-graph-average-shortest-path ctx)]
       (or (nil? value)
           (<= 1
               value
@@ -84,7 +84,7 @@
                   value
                   (count (attributes ctx)))))))
 
-(deftest test-combined-projection-vertex-degrees
+(deftest test-context-graph-vertex-degrees
   (let [ctx (make-context-from-matrix 5 3
                                       [1 1 0
                                        0 1 0
@@ -96,13 +96,13 @@
                                         0 1 1
                                         1 0 0
                                         0 1 0])]
-    (is (= (sort (combined-projection-vertex-degrees ctx))
+    (is (= (sort (context-graph-vertex-degrees ctx))
            '(1 1 2 2 2 2 3 3)))
-    (is (= (sort (combined-projection-vertex-degrees ctx1))
+    (is (= (sort (context-graph-vertex-degrees ctx1))
            '(1 1 1 2 2 2 3))))
   
   (with-testing-data [ctx (random-contexts 7 150)]
-                     (let [degrees (combined-projection-vertex-degrees ctx)
+                     (let [degrees (context-graph-vertex-degrees ctx)
                            m (count (objects ctx))
                            n (count (attributes ctx))]
                        (and (= (count degrees) (+ m n))

--- a/src/test/clojure/conexp/fca/applications/socialanalytics_test.clj
+++ b/src/test/clojure/conexp/fca/applications/socialanalytics_test.clj
@@ -12,9 +12,9 @@
                                          make-context-from-matrix
                                          objects
                                          attributes]]
-          [conexp.fca.applications.socialanalytics :refer :all]
-          [clojure.test :refer [deftest is]]
-          [conexp.base :refer [with-testing-data]]))
+            [conexp.fca.applications.socialanalytics :refer :all]
+            [clojure.test :refer [deftest is]]
+            [conexp.base :refer [with-testing-data]]))
 
 ;Average-shortest-path
 
@@ -40,7 +40,7 @@
               (+ (count (objects ctx))
                  (count (attributes ctx))))))))
 
-(deftest test-average-shortest-paths-objects
+(deftest test-object-projection-average-shortest-paths
   (let [ctx (make-context-from-matrix 3 3
                                [1 0 0
                                 1 1 1

--- a/src/test/clojure/conexp/fca/applications/socialanalytics_test.clj
+++ b/src/test/clojure/conexp/fca/applications/socialanalytics_test.clj
@@ -84,7 +84,7 @@
                   value
                   (count (attributes ctx)))))))
 
-(deftest test-vertice-degrees
+(deftest test-vertex-degrees
   (let [ctx (make-context-from-matrix 5 3
                                       [1 1 0
                                        0 1 0
@@ -96,19 +96,19 @@
                                         0 1 1
                                         1 0 0
                                         0 1 0])]
-    (is (= (sort (vertice-degrees-objects-and-attributes ctx))
+    (is (= (sort (vertex-degrees-objects-and-attributes ctx))
            '(1 1 2 2 2 2 3 3)))
-    (is (= (sort (vertice-degrees-objects-and-attributes ctx1))
+    (is (= (sort (vertex-degrees-objects-and-attributes ctx1))
            '(1 1 1 2 2 2 3))))
   
   (with-testing-data [ctx (random-contexts 7 150)]
-                     (let [degrees (vertice-degrees-objects-and-attributes ctx)
+                     (let [degrees (vertex-degrees-objects-and-attributes ctx)
                            m (count (objects ctx))
                            n (count (attributes ctx))]
                        (and (= (count degrees) (+ m n))
                             (every? #(<= 0 % (max m n)) degrees)))))
 
-(deftest test-vertice-degrees-objects
+(deftest test-vertex-degrees-objects
   (let [ctx (make-context-from-matrix 5 3
                                       [1 1 0
                                        0 1 0
@@ -120,18 +120,18 @@
                                         0 1 1
                                         1 0 0
                                         0 1 0])]
-    (is (= (sort (vertice-degrees-objects ctx))
+    (is (= (sort (vertex-degrees-objects ctx))
            '(3 3 4 4 5)))
-    (is (= (sort (vertice-degrees-objects ctx1))
+    (is (= (sort (vertex-degrees-objects ctx1))
            '(2 3 3 4))))
   
   (with-testing-data [ctx (random-contexts 7 150)]
-                     (let [degrees (vertice-degrees-objects ctx)
+                     (let [degrees (vertex-degrees-objects ctx)
                            n (count (objects ctx))]
                        (and (= (count degrees) n)
                             (every? #(<= 0 % n) degrees)))))
 
-(deftest test-vertice-degrees-attributes
+(deftest test-vertex-degrees-attributes
   (let [ctx (make-context-from-matrix 5 3
                                       [1 1 0
                                        0 1 0
@@ -142,13 +142,13 @@
                                        [1 0 0 1 0
                                         1 1 1 0 0
                                         0 0 0 1 0])]
-    (is (= (sort (vertice-degrees-attributes ctx))
+    (is (= (sort (vertex-degrees-attributes ctx))
            '(3 3 3)))
-    (is (= (sort (vertice-degrees-attributes ctx1))
+    (is (= (sort (vertex-degrees-attributes ctx1))
            '(0 2 3 3 4))))
   
   (with-testing-data [ctx (random-contexts 7 150)]
-                     (let [degrees (vertice-degrees-attributes ctx)
+                     (let [degrees (vertex-degrees-attributes ctx)
                            n (count (attributes ctx))]
                        (and (= (count degrees) n)
                             (every? #(<= 0 % n) degrees)))))


### PR DESCRIPTION
Hi Daniel,
I created a new file, socialanalytics.clj, in the directory conexp.fca.applications. Right now, this file provides the following functionality:
For a formal context, there are function to compute the average shortest path lengths for the following graphs:
- The one having the objects and attributes as verticies and the incidents as edges.
- The one having the objects as verticies and in which two objects share an edge if they share an attribute.
- The one having the attributes as verticies and in which two attributes share an edge if they share an object.

I therefore used the algrorithmm of Floyd-Warshall. As this algorithm works on the adjacency-matricies of the graphs, I implemented functions to compute the adjacency-matricies of the above discribed graphs.

For the three given types of graphs I also implemented functions to compute the vertice-degrees.
Therefore, I implemented functions which compute the graphs and return them as adjacency-maps.

Regards,
Max


